### PR TITLE
Cleanup: Replace unwraps with expects

### DIFF
--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -44,6 +44,7 @@ impl DatabaseOps for Sqlite {
     }
 
     fn insert_or_modify(&self, t: Task) -> Result<Task, DatabaseError> {
+        #[allow(unused)]
         if let Some(id) = t.id {
             // Modify
         } else {
@@ -64,6 +65,7 @@ impl DatabaseOps for Sqlite {
         Ok(t)
     }
 
+    #[allow(unused)]
     fn list(&self, status: Status) -> Result<Vec<Task>, DatabaseError> {
         Ok(Vec::new())
     }

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -18,6 +18,6 @@ impl ToSql for Status {
 impl FromSql for Status {
     fn column_result(value: ValueRef) -> Result<Self, FromSqlError> {
         let s = value.as_str()?;
-        Ok(Status::try_from(s).expect("Can't convert database entry to Status"))
+        Ok(Status::try_from(s).expect("Error converting database entry to Status"))
     }
 }

--- a/src/frontend/cli/add.rs
+++ b/src/frontend/cli/add.rs
@@ -18,7 +18,7 @@ impl TryInto<InputCommand> for Add {
         Ok(InputCommand::Add(Task {
             title: self.name,
             description: Some(self.description),
-            due: self.date.parse().unwrap(),
+            due: self.date.parse().expect("Error parsing date from cli"),
             id: None,
             status: Status::Todo,
         }))
@@ -39,7 +39,9 @@ mod tests {
             date: "Tomorrow".to_string(),
         };
 
-        let uut: InputCommand = data.try_into().unwrap();
+        let uut: InputCommand = data
+            .try_into()
+            .expect("Error making InputCommand from Cli::Add");
 
         assert_eq!(
             uut,

--- a/src/frontend/cli/ls.rs
+++ b/src/frontend/cli/ls.rs
@@ -9,6 +9,8 @@ pub struct Ls {
 impl TryInto<InputCommand> for Ls {
     type Error = CliError;
     fn try_into(self) -> Result<InputCommand, Self::Error> {
-        Ok(InputCommand::Ls(self.status.parse().unwrap()))
+        Ok(InputCommand::Ls(
+            self.status.parse().expect("Error parsing status from cli"),
+        ))
     }
 }

--- a/src/frontend/cli/mod.rs
+++ b/src/frontend/cli/mod.rs
@@ -85,14 +85,14 @@ where
                 .unwrap_or(&String::from("Indefinite"))
                 .clone(),
         })
-        .unwrap(),
+        .expect("Error making InputCommand from Cli::Add"),
         Some(("ls", sub_m)) => TryInto::<InputCommand>::try_into(Ls {
             status: sub_m
                 .get_one::<String>("status")
                 .unwrap_or(&String::from("All"))
                 .clone(),
         })
-        .unwrap(),
+        .expect("Error making InputCommand from Cli::Ls"),
         _ => panic!("Pls no"),
     }
 }

--- a/src/mw/db/mod.rs
+++ b/src/mw/db/mod.rs
@@ -3,6 +3,7 @@ use crate::{mw::task::Task, utils::Status};
 #[derive(Debug, PartialEq)]
 pub enum DatabaseError {
     CreateTableError,
+    #[allow(unused)]
     UnknownError,
 }
 

--- a/src/mw/mod.rs
+++ b/src/mw/mod.rs
@@ -24,11 +24,14 @@ impl<T: FrontEndInput, U: DatabaseOps> Middleware<T, U> {
         let command: InputCommand = self.ui.execute();
         match command {
             InputCommand::Add(t) => {
-                let inserted_task = self.db.insert_or_modify(t).unwrap();
+                let inserted_task = self
+                    .db
+                    .insert_or_modify(t)
+                    .expect("Failed insert_or_modify operation");
                 println!("{:?}", inserted_task);
             }
             InputCommand::Ls(s) => {
-                let v = self.db.list(s).unwrap();
+                let v = self.db.list(s).expect("Failed list operation");
                 println!("{:?}", v);
             }
             #[allow(unreachable_patterns)]

--- a/src/mw/ui/mod.rs
+++ b/src/mw/ui/mod.rs
@@ -1,7 +1,6 @@
 use crate::{mw::task::Task, utils::Status};
 
 #[derive(Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum InputCommand {
     Add(Task),
     Ls(Status),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -46,14 +46,16 @@ impl TryInto<NaiveDate> for DueDate {
         let today = Local::now().date_naive();
         match self {
             Self::Today => Ok(today),
-            Self::Tomorrow => Ok(today.checked_add_days(Days::new(1)).unwrap()),
+            Self::Tomorrow => Ok(today
+                .checked_add_days(Days::new(1))
+                .expect("Error adding one day to current date")),
             Self::EndOfWeek => {
                 let day = today.weekday().num_days_from_monday();
                 Ok(today
                     .checked_add_days(Days::new(day as u64 + 4u64))
-                    .unwrap())
+                    .expect("Error adding 4 days to current date"))
             }
-            Self::Other(s) => panic!("Can't make date from {}, yet!", s),
+            Self::Other(s) => panic!("Error making date from {}, yet!", s),
         }
     }
 }


### PR DESCRIPTION
We still want to panic at every error, but do it with a message.
Store Status as text in the database.